### PR TITLE
full package supports torus vs finite selection

### DIFF
--- a/gameOfLife.m
+++ b/gameOfLife.m
@@ -15,11 +15,20 @@ function outArray = gameOfLife(seedArray, worldType)
 %
 % BT, Feb 2019
 
+%% check inputs are appropriate variable types
+
+% seedArray should be a 2D matrix, class 'double'
+if ~ismatrix(seedArray) || ~isa(seedArray,'double')
+    error('seedArray input to gameOfLife must be a 2D matrix with double-precision number format')
+end
+
 % default - if world type is left empty, or unrecognised, set to torus
 possible_worldTypes = {'torus', 'finite'};
 if isempty(worldType) || all(~strcmp(worldType, possible_worldTypes))
     worldType = 'torus';
 end
+
+%% run the step
 
 % if 'torus', pad the array and copy edges across for 'wrap around' effect
 if strcmp(worldType,'torus')

--- a/testing_script.m
+++ b/testing_script.m
@@ -50,7 +50,7 @@ seedArray{4} =  [   0     0     0;
 % run the engine and check each output - only need to check central cell
 success_tally = zeros(1, length(seedArray));
 for t = 1:length(seedArray)
-    outArray = gameOfLife(seedArray{t});
+    outArray = gameOfLife(seedArray{t}, []);
     if outArray(3,3) == 0
         success_tally(t) = 1;
     end
@@ -95,7 +95,7 @@ seedArray{4} =  [   0   0   0   0   0;
 % run the engine and check each output - only need to check central cell
 success_tally = zeros(1, length(seedArray));
 for t = 1:length(seedArray)
-    outArray = gameOfLife(seedArray{t});
+    outArray = gameOfLife(seedArray{t}, []);
     if outArray(3,3) == 0
         success_tally(t) = 1;
     end
@@ -151,7 +151,7 @@ seedArray{6} =  [   0   0   0   0   0;
 % run the engine and check each output - only need to check central cell
 success_tally = zeros(1, length(seedArray));
 for t = 1:length(seedArray)
-    outArray = gameOfLife(seedArray{t});
+    outArray = gameOfLife(seedArray{t}, []);
     if outArray(3,3) == 1
         success_tally(t) = 1;
     end
@@ -211,7 +211,7 @@ seedArray{6} =  [   0   0   0   0   0;
 % run the engine and check each output - only need to check central cell
 success_tally = zeros(1, length(seedArray));
 for t = 1:length(seedArray)
-    outArray = gameOfLife(seedArray{t});
+    outArray = gameOfLife(seedArray{t}, []);
     if outArray(3,3) == 1
         success_tally(t) = 1;
     end
@@ -283,7 +283,7 @@ currentArray = seedArray;
 % run the engine and check each output - only need to check central cell
 success_tally = zeros(1, 2);
 for s = 1:2
-    currentArray = gameOfLife(currentArray);
+    currentArray = gameOfLife(currentArray, []);
     if isequal(currentArray,reqArray{s})
         success_tally(s) = 1;
     end


### PR DESCRIPTION
Updated runGameOfLife function to support gameOfLife function's option for a torus or finite world selection. worldType variable is now required input for the gameOfLife function, though if an empty or unrecognised variable is entered, it will default to 'torus'.

testing_script also updated - with typo corrected - to accommodate new required input for gameOfLife function